### PR TITLE
Update linter target

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,13 +11,23 @@ module.exports = {
     'airbnb-base',
     'airbnb-typescript/base',
   ],
+
+  overrides: [{
+    files: ['src/**/*'],
+
+    parserOptions: {
+      project: ['./tsconfig.app.json'],
+    },
+  }],
+
   parserOptions: {
     ecmaVersion: 'latest',
     ecmaFeatures: {
       useStrict: true,
     },
-    project: ['./tsconfig.app.json'],
+    project: ['./tsconfig.node.json'],
   },
+
   plugins: [
     '@typescript-eslint',
   ],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,8 +2,6 @@
   "extends": "@tsconfig/strictest/tsconfig.json",
   "include": [
     "src/**/*",
-    ".eslintrc.cjs",
-    "vite.config.ts"
   ],
   "compilerOptions": {
     "composite": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "include": [
-    "vite.config.ts",
-    ".eslintrc.cjs"
+    "**.ts",
+    "**.cjs"
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
With current configuration eslint captures files outside of src directory which causes failure to check some top-level files.